### PR TITLE
AGP version updated to 7.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Next Release
+
+### 6.4.0
+- Android Gradle Plugin version updated to `7.3.1`
+
 ### 6.3.1 (20-09-2022)
 - MoEngage SDK Version updated to `12.3.02` [Release Notes](https://developers.moengage.com/hc/en-us/articles/4403896795540-Changelog#20-09-2022-0-0)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,15 +1,10 @@
-buildscript {
-    dependencies {
-        classpath(libs.bundles.gradlePlugins)
-    }
-}
-
 @Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     alias(moengageInternal.plugins.plugin.android.app) apply false
     alias(moengageInternal.plugins.plugin.android.lib) apply false
     alias(moengageInternal.plugins.plugin.kotlin.android) apply false
     alias(moengageInternal.plugins.plugin.dokka) apply false
+    id("com.google.gms.google-services") version "4.3.14" apply false
 }
 
 subprojects {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,3 @@
 [libraries]
 moengageCore = { module = "com.moengage:moe-android-sdk", version = "12.3.02" }
 segment = { module = "com.segment.analytics.android:analytics", version = "4.9.0" }
-# plugins
-gradlePlugin-googleService = { module = "com.google.gms:google-services", version = "4.3.10" }
-
-[bundles]
-gradlePlugins = ["gradlePlugin-googleService"]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,11 +14,10 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        maven(url = "https://oss.sonatype.org/content/repositories/snapshots/")
     }
     versionCatalogs {
         create("moengageInternal") {
-            from("com.moengage:android-dependency-catalog-internal:1.2.1-SNAPSHOT")
+            from("com.moengage:android-dependency-catalog-internal:1.2.0")
         }
         create("moengage") {
             from("com.moengage:android-dependency-catalog:2.5.1")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,10 +14,11 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven(url = "https://oss.sonatype.org/content/repositories/snapshots/")
     }
     versionCatalogs {
         create("moengageInternal") {
-            from("com.moengage:android-dependency-catalog-internal:1.1.0")
+            from("com.moengage:android-dependency-catalog-internal:1.2.1-SNAPSHOT")
         }
         create("moengage") {
             from("com.moengage:android-dependency-catalog:2.5.1")


### PR DESCRIPTION
Android Gradle Plugin updated to 7.3.1

The Google Services plugin was updated along with it as the older version wasn't compatible with latest AGP.