### PR TITLE
Add commit changes step after verify build in update SDK workflow

### DIFF
--- a/.github/workflows/update_moengage_sdk.yaml
+++ b/.github/workflows/update_moengage_sdk.yaml
@@ -43,6 +43,16 @@ jobs:
         uses: ./sdk-automation-scripts/actions/android-build-verification
         with:
           working-directory: source
+      - name: Commit changes
+        working-directory: source
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            git add -A
+            git commit -m "${{ github.event.inputs.ticket_number }}: Update moe-android-sdk version to ${{ github.event.inputs.moengage_version }}"
+            git push
+          else
+            echo "No changes to commit."
+          fi
       - name: Trigger release workflow
         working-directory: source
         run: |


### PR DESCRIPTION
## Summary
- Adds a **Commit changes** step after **Verify build** in `update_moengage_sdk.yaml`
- The step checks for a dirty working tree via `git status --porcelain`, and only stages, commits (with the ticket number + version in the message), and pushes when there are actual changes; otherwise logs "No changes to commit."

## Notes
- Assumes the `common-repo-setup` action configures git identity and push credentials. If not, a `git config` + auth step may be needed for the push to succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)